### PR TITLE
Fix Renovate settings for Github Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,16 +12,16 @@ jobs:
     concurrency:
       group: "${{ github.workflow }}-${{ github.ref }}"
     steps:
-      - uses: "actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c"
+      - uses: "actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c" # renovate: tag=v3.5.0
 
       - name: "Set up Hugo"
-        uses: "peaceiris/actions-hugo@16361eb4acea8698b220b76c0d4e84e1fd22c61d"
+        uses: "peaceiris/actions-hugo@16361eb4acea8698b220b76c0d4e84e1fd22c61d" # renovate: tag=v2.6.0
         with:
           hugo-version: "0.111.3"
           extended: true
 
       - name: "Set up Node.js"
-        uses: "actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c"
+        uses: "actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c" # renovate: tag=v3.6.0
         with:
           node-version: 18
 
@@ -35,7 +35,7 @@ jobs:
         run: "npm run build"
 
       - name: "Deploy"
-        uses: "peaceiris/actions-gh-pages@bd8c6b06eba6b3d25d72b7a1767993c0aeee42e7"
+        uses: "peaceiris/actions-gh-pages@bd8c6b06eba6b3d25d72b7a1767993c0aeee42e7" # renovate: tag=v3.9.2
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
           publish_dir: "./public"


### PR DESCRIPTION
## 変更点

- Renovate が action の最新 commit ではなく，**最新リリースタグに追従するよう修正**しました。
  - cf. <https://docs.renovatebot.com/modules/manager/github-actions/>