### PR TITLE
Allow the `<iframe>` of Google Calendar to scroll when it overflows

### DIFF
--- a/layouts/partials/home/event.html
+++ b/layouts/partials/home/event.html
@@ -20,7 +20,6 @@
         width="320"
         height="240"
         frameborder="0"
-        scrolling="no"
         loading="lazy"
         title="{{ .Name }}"
         class="event__google-calendar"


### PR DESCRIPTION
## 変更点

Google Calendar の埋め込み部分（新歓スケジュール）で reCAPTCHA が表示された場合，`<iframe>` がスクロール不可能な設定のため認証操作ができないことがある状態を解消しました。

---

少し調べたところ，どうやらこの reCAPTCHA が現れる事象は，iOS 版 Safari からアクセスするとデフォルトの設定が影響して起こりやすい模様です。ただ，手元に iPhone がないのでこちらで検証はできていません。

- https://support.google.com/calendar/thread/168984025/embedded-google-calendar-not-showing-in-website-a-recaptcha-not-a-robot-shows-instead
- https://discussions.apple.com/thread/254376821
