### PR TITLE
LINEオープンチャットURLの差し替え

### DIFF
--- a/config/_default/hugo.yml
+++ b/config/_default/hugo.yml
@@ -27,7 +27,7 @@ menu:
       weight: 20
     - identifier: "line"
       name: "LINE オープンチャット"
-      url: "https://line.me/ti/g2/HParErij--I835lSEnSJeevqTnb_YTRqx-Movw"
+      url: "https://line.me/ti/g2/UfhEOyteJRjyQLm-c9Mmhj_9wvIKCBDEohh_WQ"
       weight: 30
     - identifier: "digicre"
       name: "ウェブサイト"

--- a/content/faq/上記以外に質問があるのですが、どうしたら良いですか？.md
+++ b/content/faq/上記以外に質問があるのですが、どうしたら良いですか？.md
@@ -5,4 +5,4 @@ _build:
   list: "local"
 ---
 
-[デジクリ公式 Twitter](https://twitter.com/sitdigicre)宛に DM をお送りいただくか、[LINE オープンチャット](https://line.me/ti/g2/HParErij--I835lSEnSJeevqTnb_YTRqx-Movw)または[メール](mailto:contact@digicre.net)にてお問い合わせください。
+[デジクリ公式 Twitter](https://twitter.com/sitdigicre)宛に DM をお送りいただくか、[LINE オープンチャット](https://line.me/ti/g2/UfhEOyteJRjyQLm-c9Mmhj_9wvIKCBDEohh_WQ)または[メール](mailto:contact@digicre.net)にてお問い合わせください。

--- a/content/join-us/_index.md
+++ b/content/join-us/_index.md
@@ -6,4 +6,4 @@ _build:
 
 **入部受付フォーム**から登録されたメールアドレス宛に、**入部方法や見学等のご案内メール**をお送りします。
 
-また、[LINE オープンチャット](https://line.me/ti/g2/HParErij--I835lSEnSJeevqTnb_YTRqx-Movw)も開設しています。デジクリのイベント情報を配信するほか、**匿名でデジクリ部員に質問する**ことが可能です。
+また、[LINE オープンチャット](https://line.me/ti/g2/UfhEOyteJRjyQLm-c9Mmhj_9wvIKCBDEohh_WQ)も開設しています。デジクリのイベント情報を配信するほか、**匿名でデジクリ部員に質問する**ことが可能です。

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,162 +1,115 @@
 <!doctype html>
 <html lang="ja">
-  <head prefix="og: https://ogp.me/ns#">
-    <meta charset="UTF-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1.0"
-    />
-    <meta
-      name="description"
-      content="{{ .Site.Params.description }}"
-    />
-    <title>{{ .Title }}</title>
 
-    {{/* OGP */}}
-    {{ partial  "ogp.html" . }}
+<head prefix="og: https://ogp.me/ns#">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="{{ .Site.Params.description }}" />
+  <title>{{ .Title }}</title>
 
-    {{/* Favicon */}}
-    {{ partial  "favicon.html" . }}
+  {{/* OGP */}}
+  {{ partial "ogp.html" . }}
 
-    {{/* For preview build */}}
-    {{ if eq hugo.Environment "development" }}
-      <meta
-        name="robots"
-        content="noindex"
-      />
-    {{ end }}
+  {{/* Favicon */}}
+  {{ partial "favicon.html" . }}
 
-    {{/* The New CSS Reset */}}
-    {{ with resources.GetRemote "https://cdn.jsdelivr.net/npm/the-new-css-reset@latest/css/reset.css" | minify }}
-      <link
-        rel="stylesheet"
-        href="{{ .Permalink }}"
-      />
-    {{ end }}
+  {{/* For preview build */}}
+  {{ if eq hugo.Environment "development" }}
+  <meta name="robots" content="noindex" />
+  {{ end }}
 
-    {{/* CSS */}}
-    {{ with resources.Get "scss/style.scss" | resources.ToCSS | resources.Fingerprint }}
-      <link
-        rel="stylesheet"
-        href="{{ .Permalink }}"
-      />
-    {{ end }}
+  {{/* The New CSS Reset */}}
+  {{ with resources.GetRemote "https://cdn.jsdelivr.net/npm/the-new-css-reset@latest/css/reset.css" | minify }}
+  <link rel="stylesheet" href="{{ .Permalink }}" />
+  {{ end }}
 
-    {{/* Google Fonts */}}
+  {{/* CSS */}}
+  {{ with resources.Get "scss/style.scss" | css.Sass| resources.Fingerprint }}
+  <link rel="stylesheet" href="{{ .Permalink }}" />
+  {{ end }}
+
+  {{/* Google Fonts */}}
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    data-href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Noto+Sans+JP:wght@400;700&display=swap"
+    rel="stylesheet" id="google-fonts" />
+  <noscript>
     <link
-      rel="preconnect"
-      href="https://fonts.googleapis.com"
-    />
-    <link
-      rel="preconnect"
-      href="https://fonts.gstatic.com"
-      crossorigin
-    />
-    <link
-      data-href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Noto+Sans+JP:wght@400;700&display=swap"
-      rel="stylesheet"
-      id="google-fonts"
-    />
-    <noscript>
-      <link
-        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Noto+Sans+JP:wght@400;700&display=swap"
-        rel="stylesheet"
-      />
-    </noscript>
-  </head>
-  <body class="body">
-    <header class="header">
-      {{/* トグル */}}
-      <input
-        type="checkbox"
-        name="toggle"
-        id="header-toggle"
-        class="header__toggle"
-      />
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Noto+Sans+JP:wght@400;700&display=swap"
+      rel="stylesheet" />
+  </noscript>
+</head>
 
-      {{/* ヘッダー開ボタン */}}
-      <label
-        for="header-toggle"
-        class="header__toggle-button header__toggle-button--open"
-        aria-label="メニューを開く"
-      >
-        {{ (resources.Get "img/icons/menu.svg").Content | safeHTML }}
+<body class="body">
+  <header class="header">
+    {{/* トグル */}}
+    <input type="checkbox" name="toggle" id="header-toggle" class="header__toggle" />
+
+    {{/* ヘッダー開ボタン */}}
+    <label for="header-toggle" class="header__toggle-button header__toggle-button--open" aria-label="メニューを開く">
+      {{ (resources.Get "img/icons/menu.svg").Content | safeHTML }}
+    </label>
+
+    {{/* ヘッダー */}}
+    <div class="header__wrapper">
+      {{/* ヘッダー閉ボタン */}}
+      <label for="header-toggle" class="header__toggle-button header__toggle-button--close" aria-label="メニューを閉じる">
+        {{ (resources.Get "img/icons/close.svg").Content | safeHTML }}
       </label>
 
-      {{/* ヘッダー */}}
-      <div class="header__wrapper">
-        {{/* ヘッダー閉ボタン */}}
-        <label
-          for="header-toggle"
-          class="header__toggle-button header__toggle-button--close"
-          aria-label="メニューを閉じる"
-        >
-          {{ (resources.Get "img/icons/close.svg").Content | safeHTML }}
-        </label>
+      {{/* ロゴ */}}
+      <a href="{{ .Site.Home.Permalink }}" class="logo" aria-label="デジクリ">
+        {{ (resources.Get "img/logo.svg").Content | safeHTML }}
+      </a>
 
-        {{/* ロゴ */}}
-        <a
-          href="{{ .Site.Home.Permalink }}"
-          class="logo"
-          aria-label="デジクリ"
-        >
-          {{ (resources.Get "img/logo.svg").Content | safeHTML }}
-        </a>
+      {{/* 目次 */}}
+      <nav class="menu">
+        <ul>
+          {{ block "toc" . }}
+          {{ end }}
+        </ul>
+      </nav>
 
-        {{/* 目次 */}}
-        <nav class="menu">
-          <ul>
-            {{ block "toc" . }}
-            {{ end }}
-          </ul>
-        </nav>
+      {{/* 関連リンク */}}
+      <nav class="menu">
+        <ul>
+          {{ range index .Site.Menus "links" }}
+          <li>
+            <a href="{{ .URL }}" rel="noopener" target="_blank" class="menu__item">
+              {{/* アイコン */}}
+              {{ (resources.Get (print "img/icons/" .Identifier ".svg")).Content | safeHTML }}
 
-        {{/* 関連リンク */}}
-        <nav class="menu">
-          <ul>
-            {{ range index .Site.Menus "links" }}
-              <li>
-                <a
-                  href="{{ .URL }}"
-                  rel="noopener"
-                  target="_blank"
-                  class="menu__item"
-                >
-                  {{/* アイコン */}}
-                  {{ (resources.Get (print "img/icons/" .Identifier ".svg")).Content | safeHTML }}
+              {{/* タイトル */}}
+              {{ .Name }}
 
-                  {{/* タイトル */}}
-                  {{ .Name }}
+              {{/* 新規タブで開くアイコン */}}
+              {{ (resources.Get "img/icons/open-in-new.svg").Content | safeHTML }}
+            </a>
+          </li>
+          {{ end }}
+        </ul>
+      </nav>
+    </div>
+  </header>
 
-                  {{/* 新規タブで開くアイコン */}}
-                  {{ (resources.Get "img/icons/open-in-new.svg").Content | safeHTML }}
-                </a>
-              </li>
-            {{ end }}
-          </ul>
-        </nav>
-      </div>
-    </header>
-
-    <main>
-      {{ block "main" . }}
-      {{ end }}
-    </main>
-
-    <footer class="footer">
-      <small>© 2004-2024 芝浦工業大学 デジクリ</small>
-    </footer>
-
-    {{/* 共通 JavaScript */}}
-    {{ with resources.Get "js/index.js" | js.Build | minify | resources.Fingerprint }}
-      <script
-        src="{{ .Permalink }}"
-        defer
-      ></script>
+  <main>
+    {{ block "main" . }}
     {{ end }}
+  </main>
 
-    {{/* 各ページ用の JavaScript */}}
-    {{ block "script" . }}
-    {{ end }}
-  </body>
+  <footer class="footer">
+    <small>© 2004-2024 芝浦工業大学 デジクリ</small>
+  </footer>
+
+  {{/* 共通 JavaScript */}}
+  {{ with resources.Get "js/index.js" | js.Build | minify | resources.Fingerprint }}
+  <script src="{{ .Permalink }}" defer></script>
+  {{ end }}
+
+  {{/* 各ページ用の JavaScript */}}
+  {{ block "script" . }}
+  {{ end }}
+</body>
+
 </html>


### PR DESCRIPTION
- URLを2025年度のものに差し替え
- resources.ToCSS がHugo v0.128.0で廃止されていたため css.Sass に更新