### PR TITLE
fix: デプロイワークフローの修正

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,14 +20,14 @@ jobs:
           hugo-version: "0.145.0"
           extended: true
 
+      - name: "Enable pnpm"
+        run: "corepack enable"
+
       - name: "Set up Node.js"
         uses: "actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a" # v4.2.0
         with:
           node-version: "24"
           cache: "pnpm"
-
-      - name: "Enable pnpm"
-        run: "corepack enable"
 
       - name: "Install pnpm dependencies"
         run: "pnpm install --frozen-lockfile"


### PR DESCRIPTION
corepackの有効化はnodeのインストール前にやる必要があったため修正

ref: https://github.com/newt239/next-score-watcher/blob/main/.github/workflows/lint.yml